### PR TITLE
Add ChatBot component to page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import ChatBot from "./components/ChatBot";
 
 const heroImage =
   "https://www.figma.com/api/mcp/asset/67f33af7-96af-4cb2-8fcd-8b8eedbec74e";
@@ -329,6 +330,9 @@ export default function Home() {
           </p>
         </div>
       </footer>
+
+      {/* Copilot ChatBot */}
+      <ChatBot />
     </div>
   );
 }


### PR DESCRIPTION
## 変更内容

`ChatBot` コンポーネントが `page.tsx` にインポート・レンダリングされていなかったため、デプロイされたページにCopilot SDKチャットボットが表示されていませんでした。

### 修正
- `page.tsx` に `ChatBot` コンポーネントをインポート
- フッターの下に `<ChatBot />` を追加

これにより、ページ右下にイベントアシスタントのチャットボットが表示されます。