### PR TITLE
fix: welcome icon background to solid #818b98 per Figma spec

### DIFF
--- a/src/app/components/ChatBot.tsx
+++ b/src/app/components/ChatBot.tsx
@@ -262,7 +262,7 @@ export default function ChatBot() {
           <div className="flex h-[400px] flex-col overflow-y-auto bg-[#f6f8fa] px-4 py-4">
             {showWelcome ? (
               <div className="flex flex-1 flex-col items-center justify-center">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[rgba(129,139,152,0.12)] text-[#59636e]">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#818b98] text-white">
                   <CopilotIcon size={24} />
                 </div>
                 <p className="mt-4 text-base font-semibold text-[#010409]">


### PR DESCRIPTION
Welcome state icon background: `rgba(129,139,152,0.12)` (12% opacity) → `#818b98` (solid). Icon color updated to white for contrast.

Addresses #27