### PR TITLE
docs: add color palette documentation for design change tracking

### DIFF
--- a/.github/workflows/docs-sync.md
+++ b/.github/workflows/docs-sync.md
@@ -95,6 +95,7 @@ Document each React component:
 - Props interface (if any) with types and descriptions
 - Key behaviors and state management
 - Dependencies on external services or APIs
+- **Color palette**: For each component, list **every** hex color and rgba value used in the source code. Present as a table with columns: Color name, Hex/RGBA value, Usage description. Extract colors from Tailwind arbitrary values (e.g. `bg-[#1f883d]`), inline styles, and SVG attributes (e.g. `stroke="#25292e"`). This is critical for design consistency tracking.
 - Tailwind CSS patterns used
 
 ### `docs/configuration.md`

--- a/docs/components.md
+++ b/docs/components.md
@@ -89,6 +89,22 @@ interface Message {
 | `ChatIcon` | Sparkle/star SVG icon for the FAB |
 | `TypingIndicator` | Animated three-dot typing indicator |
 
+**Color palette**:
+
+| Color | Hex Value | Usage |
+|-------|-----------|-------|
+| Primary green | `#1f883d` | Header avatar background, user message bubbles, send button icon background, FAB button (closed state), status indicator ("● オンライン") |
+| Dark text | `#010409` | Header title, user/bot message text, quick action button text |
+| Secondary text gray | `#59636e` | Subtitle text, "入力中..." label, "Powered by GitHub Copilot" text, typing indicator dots |
+| Border gray | `#d1d9e0` | Chat window border, header/input area borders, message bubble borders, input field border, quick action button borders |
+| Light background | `#f6f8fa` | Message area background, quick action hover state, FAB button (open state) |
+| Welcome avatar gray | `#818b98` | Welcome section Copilot avatar background |
+| Input placeholder | `rgba(1,4,9,0.5)` | Input field placeholder text |
+| Shadow (window) | `rgba(0,0,0,0.12)` | Chat window drop shadow |
+| Shadow (FAB) | `rgba(31,35,40,0.04)` | Floating action button shadow |
+| Icon stroke (close) | `#25292e` | Close icon SVG stroke |
+| Icon stroke (send) | `#57606a` | Send icon SVG stroke |
+
 **Tailwind patterns**:
 - Fixed positioning: `fixed bottom-6 right-6 z-[100]`
 - Chat window: `w-[327px]`, `h-[400px]` scrollable message area


### PR DESCRIPTION
## Summary

Adds comprehensive color palette documentation to `docs/components.md` and updates the docs-sync agent prompt to require color values for every component.

### Changes
- **`docs/components.md`**: Added a color palette table to the ChatBot section listing all 11 hex/rgba color values used in the component
- **`.github/workflows/docs-sync.md`**: Updated the prompt to instruct the agent to extract and document all color values (hex, rgba) from Tailwind classes, inline styles, and SVG attributes

### Why
Previously, color changes in components were not detected by the Documentation Sync Agent because colors were not part of the documented specification. With this change, any future color modification will cause the docs-sync agent to detect the drift and create a PR to update the documentation.