### PR TITLE
docs: revert status indicator color to pre-PR#51 value for sync detection

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -93,7 +93,8 @@ interface Message {
 
 | Color | Hex Value | Usage |
 |-------|-----------|-------|
-| Primary green | `#1f883d` | Header avatar background, user message bubbles, send button icon background, FAB button (closed state), status indicator ("● オンライン") |
+| Primary green | `#1f883d` | Header avatar background, user message bubbles, send button icon background, FAB button (closed state) |
+| Status indicator | `#bf3989` | Online status indicator ("● オンライン") |
 | Dark text | `#010409` | Header title, user/bot message text, quick action button text |
 | Secondary text gray | `#59636e` | Subtitle text, "入力中..." label, "Powered by GitHub Copilot" text, typing indicator dots |
 | Border gray | `#d1d9e0` | Chat window border, header/input area borders, message bubble borders, input field border, quick action button borders |


### PR DESCRIPTION
## Purpose

Reverts the documented status indicator color back to `#bf3989` (the old value before PR #51) so that the Documentation Sync Agent can detect the mismatch with the actual code value `#1f883d` and create an automatic update PR.

### Background
- PR #51 changed the status indicator color from `#bf3989` to `#1f883d`
- The color palette documentation was added *after* the code change, so the agent never saw the drift
- This intentionally introduces a docs ↔ code mismatch to trigger proper detection